### PR TITLE
Fix #3: UFWファイアウォール設定エラーの修正

### DIFF
--- a/scripts/auto-setup-claude-container.sh
+++ b/scripts/auto-setup-claude-container.sh
@@ -418,13 +418,16 @@ configure_security_tools() {
     }
     
     # Configure UFW
-    lxc exec "$CONTAINER_NAME" -- bash -c '
+    # Get actual LXC bridge network
+    LXC_NETWORK=$(lxc network get lxdbr0 ipv4.address 2>/dev/null || echo "10.119.132.0/24")
+    
+    lxc exec "$CONTAINER_NAME" -- bash -c "
         ufw --force enable
         ufw default deny incoming
         ufw default allow outgoing
         ufw allow ssh
-        ufw allow from 10.x.x.0/24
-    ' || {
+        ufw allow from $LXC_NETWORK
+    " || {
         warning "UFW設定に失敗しました"
     }
     


### PR DESCRIPTION
## Summary
- ハードコードされた無効なIPアドレス`10.x.x.0/24`を動的なネットワーク検出に置き換えました
- LXCブリッジネットワーク設定から実際のネットワークアドレスを取得するように修正
- エラー時のフォールバック値を設定

## Changes
- `scripts/auto-setup-claude-container.sh`の426行目を修正
- `lxc network get lxdbr0 ipv4.address`コマンドで動的にネットワークアドレスを取得
- デフォルト値として`10.119.132.0/24`を使用

## Test plan
- [ ] auto-setup-claude-container.shスクリプトを実行
- [ ] UFW設定が正常に完了することを確認
- [ ] `lxc exec <container> -- ufw status numbered`でルールが正しく設定されていることを確認
- [ ] 外部SSH接続が引き続き動作することを確認

Closes #3

🤖 Generated with [Claude Code](https://claude.ai/code)